### PR TITLE
timeout: refactor the timeout engine

### DIFF
--- a/include/KalangoRTOS/priority_queue.h
+++ b/include/KalangoRTOS/priority_queue.h
@@ -94,5 +94,15 @@ struct heap_node *pq_peek(struct priority_queue *pq);
  */
 void pq_reorder(struct priority_queue *pq);
 
+/**
+ * pq_remove - Remove the specified note from the pq
+ * @pq: Pointer to the priority queue
+ * @node: Pointer to the node to be inserted
+ *
+ * Return: 0 on success, -EINVAL on invalid parameters
+ * @note: you MUST reorder the pq after calling this function
+ */
+int pq_remove(struct priority_queue *pq, struct heap_node *node);
+
 #endif /* PRIORITY_QUEUE_H */
 

--- a/source/timer.c
+++ b/source/timer.c
@@ -54,10 +54,13 @@ TimerId TimerCreate(TimerCallback callback, uint32_t expiry_time, uint32_t perio
 KernelResult TimerStart(TimerId timer) {
     ASSERT_PARAM(timer);
     Timer * t = (Timer *)timer;
+    KernelResult result = kSuccess;
 
     CoreSchedulingSuspend();
-    KernelResult result = RemoveTimeout(&t->timeout);
-
+    if(t->running) {
+        result = RemoveTimeout(&t->timeout);
+    }
+    
     if(result == kSuccess) {
         result = AddTimeout(&t->timeout, t->expiry_time, TimerHandleExpired);
         if(result == kSuccess) {


### PR DESCRIPTION
* Use a quasi-heap sort based implementation
* Avoid to transverse the timer list if its not necessary